### PR TITLE
Add bindings for Windows Mixed Reality controllers

### DIFF
--- a/SubmersedVR/StreamingAssets/SteamVR/actions.json
+++ b/SubmersedVR/StreamingAssets/SteamVR/actions.json
@@ -251,6 +251,10 @@
     {
       "controller_type": "knuckles",
       "binding_url": "bindings_knuckles.json"
+    },
+    {
+      "controller_type": "holographic_controller",
+      "binding_url": "bindings_holographic.json"
     }
   ],
   "localization": [

--- a/SubmersedVR/StreamingAssets/SteamVR/bindings_holographic.json
+++ b/SubmersedVR/StreamingAssets/SteamVR/bindings_holographic.json
@@ -1,0 +1,252 @@
+{
+   "action_manifest_version" : 0,
+   "alias_info" : {},
+   "app_key" : "steam.app.264710",
+   "bindings" : {
+      "/actions/subnautica" : {
+         "haptics" : [
+            {
+               "output" : "/actions/subnautica/out/hapticsleft",
+               "path" : "/user/hand/left/output/haptic"
+            },
+            {
+               "output" : "/actions/subnautica/out/hapticsright",
+               "path" : "/user/hand/right/output/haptic"
+            }
+         ],
+         "poses" : [
+            {
+               "output" : "/actions/subnautica/in/lefthandpose",
+               "path" : "/user/hand/left/pose/raw"
+            },
+            {
+               "output" : "/actions/subnautica/in/righthandpose",
+               "path" : "/user/hand/right/pose/raw"
+            }
+         ],
+         "skeleton" : [
+            {
+               "output" : "/actions/subnautica/in/lefthandskeleton",
+               "path" : "/user/hand/left/input/skeleton/left"
+            },
+            {
+               "output" : "/actions/subnautica/in/righthandskeleton",
+               "path" : "/user/hand/right/input/skeleton/right"
+            }
+         ],
+         "sources" : [
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/jump"
+                  },
+                  "position" : {
+                     "output" : "/actions/subnautica/in/move"
+                  }
+               },
+               "mode" : "joystick",
+               "path" : "/user/hand/left/input/joystick"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/movedown"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/grip"
+            },
+            {
+               "inputs" : {
+                  "north" : {
+                     "output" : "/actions/subnautica/in/pda"
+                  },
+                  "south" : {
+                     "output" : "/actions/subnautica/in/reload"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "click"
+               },
+               "path" : "/user/hand/left/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "south" : {
+                     "output" : "/actions/subnautica/in/uiclear"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "click"
+               },
+               "path" : "/user/hand/left/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/righthand"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/trigger"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/uisubmit"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/trigger"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/openquickslotwheel"
+                  },
+                  "position" : {
+                     "output" : "/actions/subnautica/in/look"
+                  }
+               },
+               "mode" : "joystick",
+               "path" : "/user/hand/right/input/joystick"
+            },
+            {
+               "inputs" : {
+                  "north" : {
+                     "output" : "/actions/subnautica/in/exit"
+                  },
+                  "south" : {
+                     "output" : "/actions/subnautica/in/alttool"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "click"
+               },
+               "path" : "/user/hand/right/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "north" : {
+                     "output" : "/actions/subnautica/in/uicancel"
+                  },
+                  "south" : {
+                     "output" : "/actions/subnautica/in/uisubmit"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "click"
+               },
+               "path" : "/user/hand/right/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "south" : {
+                     "output" : "/actions/subnautica/in/lefthand"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "click"
+               },
+               "path" : "/user/hand/right/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/lefthand"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/trigger"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/moveup"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/grip"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/builderrotateright"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/grip"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/subnautica/in/builderrotateleft"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/grip"
+            },
+            {
+               "inputs" : {
+                  "east" : {
+                     "output" : "/actions/subnautica/in/moveright"
+                  },
+                  "north" : {
+                     "output" : "/actions/subnautica/in/moveforward"
+                  },
+                  "south" : {
+                     "output" : "/actions/subnautica/in/movebackward"
+                  },
+                  "west" : {
+                     "output" : "/actions/subnautica/in/moveleft"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "touch"
+               },
+               "path" : "/user/hand/left/input/joystick"
+            },
+            {
+               "inputs" : {
+                  "east" : {
+                     "output" : "/actions/subnautica/in/builderrotateright"
+                  },
+                  "south" : {
+                     "output" : "/actions/subnautica/in/deconstruct"
+                  },
+                  "west" : {
+                     "output" : "/actions/subnautica/in/builderrotateleft"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "touch"
+               },
+               "path" : "/user/hand/right/input/joystick"
+            },
+            {
+               "inputs" : {
+                  "position" : {
+                     "output" : "/actions/subnautica/in/uiscroll"
+                  }
+               },
+               "mode" : "joystick",
+               "path" : "/user/hand/right/input/joystick"
+            }
+         ]
+      }
+   },
+   "category" : "steamvr_input",
+   "controller_type" : "holographic_controller",
+   "description" : "",
+   "interaction_profile" : "",
+   "name" : "Default SubmersedVR Bindings for Windows Mixed Reality Controller",
+   "options" : {},
+   "simulated_actions" : []
+}


### PR DESCRIPTION
These bindings are basically copied from the Oculus Touch bindings and adapted for the Windows Mixed Reality controllers. They have been tested to work on Samsung Mixed Reality controllers. By default, clicking on a joystick opens SteamVR menu, so that needs to be turned off from SteamVR settings.