### PR TITLE
Update csproj and dependencies for 2025 patch + minor code fixes that shouldn't affect logic

### DIFF
--- a/SubmersedVR/Input/FpsInputPatch.cs
+++ b/SubmersedVR/Input/FpsInputPatch.cs
@@ -72,10 +72,10 @@ namespace SubmersedVR
             GetPointerData(__instance, -3, out var data2, create: true);
             __instance.CopyFromTo(leftData, data2);
             data2.button = PointerEventData.InputButton.Middle;
-            if (GameInput.GetPrimaryDevice() == GameInput.Device.Controller)
+            if (GameInput.PrimaryDevice == GameInput.Device.Controller)
             {
-                var buttonDown = GameInput.GetButtonDown(uGUI.button2);
-                var buttonUp = GameInput.GetButtonUp(uGUI.button2);
+                var buttonDown = GameInput.GetButtonDown(GameInput.button2);
+                var buttonUp = GameInput.GetButtonUp(GameInput.button2);
                 if (__instance.m_MouseState.GetButtonState(PointerEventData.InputButton.Middle).eventData.buttonState == PointerEventData.FramePressState.NotChanged)
                 {
                     __instance.m_MouseState.SetButtonState(PointerEventData.InputButton.Middle, FPSInputModule.ConstructPressState(buttonDown, buttonUp), data2);

--- a/SubmersedVR/Input/SteamVrGameInput.cs
+++ b/SubmersedVR/Input/SteamVrGameInput.cs
@@ -124,7 +124,7 @@ namespace SubmersedVR
         {
             // Choose XBox, since it has the ABXY from Quest controllers
             GameInput.chosenControllerLayout = GameInput.ControllerLayout.Xbox360;
-            GameInput.lastDevice = GameInput.Device.Controller;
+            GameInput.lastPrimaryDevice = GameInput.Device.Controller;
             return false;
         }
     }

--- a/SubmersedVR/Input/SteamVrGameInput.cs
+++ b/SubmersedVR/Input/SteamVrGameInput.cs
@@ -337,7 +337,7 @@ namespace SubmersedVR
     [HarmonyPatch(typeof(GameInput), nameof(GameInput.UpdateAxisValues))]
     public static class SteamVrDontUpdateAxisValues
     {
-        static bool Prefix(GameInput __instance, bool useKeyboard, bool useController)
+        static bool Prefix(bool useKeyboard, bool useController)
         {
             if (Settings.IsDebugEnabled)
             {
@@ -355,7 +355,7 @@ namespace SubmersedVR
     [HarmonyPatch(typeof(GameInput), nameof(GameInput.AnyKeyDown))]
     public static class SteamVRPressAnyKey
     {
-        static void Postfix(GameInput __instance, ref bool __result)
+        static void Postfix(ref bool __result)
         {
             if (__result)
             {

--- a/SubmersedVR/SubmersedVR.csproj
+++ b/SubmersedVR/SubmersedVR.csproj
@@ -19,35 +19,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.0" />
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" />
     <PackageReference Include="UnityEngine.Modules" Version="2019.4.36" IncludeAssets="compile" />
+    <PackageReference Include="Unity.InputSystem" Version="1.4.1" IncludeAssets="compile" />
+    <PackageReference Include="Subnautica.GameLibs" Version="82304.0.0-r.0" />
+    <PackageReference Include="Subnautica.Nautilus" Version="1.*-*"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>$(SubnauticaDir)\BepInEx\core\0Harmony.dll</HintPath>
-    </Reference>
-    <!-- Main Game Assemblies -->
-    <Reference Include="Assembly-CSharp" Publicize="true">
-      <HintPath>$(SubnauticaDir)\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass" Publicize="true">
-      <HintPath>$(SubnauticaDir)\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-
-    <!-- UnityEngine: UI and TextMeshPro. Missing from the BepInEx/Nuget Package. -->
-    <Reference Include="Unity.TextMeshPro" Publicize="true">
-      <HintPath>$(SubnauticaDir)\Subnautica_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>$(SubnauticaDir)\Subnautica_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="FMODUnity">
-      <HintPath>$(SubnauticaDir)\Subnautica_Data\Managed\FMODUnity.dll</HintPath>
-    </Reference>
+    
 
     <!-- SteamVR + SteamVR Actions: Currenlty prebuilt, should be built from source later -->
     <Reference Include="SteamVR">

--- a/SubmersedVR/Tweaks/SnapTurning.cs
+++ b/SubmersedVR/Tweaks/SnapTurning.cs
@@ -467,7 +467,7 @@ namespace SubmersedVR
             {
                 if (GameInput.GetButtonDown(GameInput.Button.AutoMove))
                 {
-                    GameInput.SetAutoMove(!GameInput.GetAutoMove());
+                    GameInput.AutoMove = !GameInput.AutoMove;
                 }
                 if (!__instance.IsReady() && LargeWorldStreamer.main.IsWorldSettled())
                 {

--- a/SubmersedVR/Tweaks/VirtualKeyboard.cs
+++ b/SubmersedVR/Tweaks/VirtualKeyboard.cs
@@ -86,7 +86,7 @@ namespace SubmersedVR
     }
 
     // Open virtual keyboard once the input field was activated
-    [HarmonyPatch(typeof(TMP_InputField), nameof(TMP_InputField.ActivateInputFieldInternal))]
+    [HarmonyPatch(typeof(TMP_InputField), nameof(TMP_InputField.ActivateInputField))]
     static class ShowVirtualKeyboardOnFocus
     {
         public static void Postfix(TMP_InputField __instance)


### PR DESCRIPTION
Updates to the csproj/dependencies:
- Now references the 2025 patch version of the game libraries through the Subnautica.GameLibs package
- Now references the Unity Input System module, which is now part of all Subnautica mod templates
- Now references the latest Subnautica.Nautilus package
- Now targets more specific versions of the BepInEx packages (a mostly meaningless change)
- Removed old unused references

Code updates:
- I tried to not change the logic at all in places where code was heavily changed, though I still fixed some compiler errors that occurred from members being removed and/or renamed
- Accounted for the GameInput class becoming static